### PR TITLE
Refactor some confirmation table stuff to use React component, improved types, less state

### DIFF
--- a/ccm_web/client/src/components/BulkSectionCreateUploadConfirmationTable.tsx
+++ b/ccm_web/client/src/components/BulkSectionCreateUploadConfirmationTable.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react'
-import renderTable from './ConfirmationTableTableRenderer'
+import React, { useState } from 'react'
+import ConfirmationTable from './ConfirmationTable'
 
 interface Section {
   rowNumber: number
@@ -23,19 +23,11 @@ const columns: TableHeaderColumnInfoShouldUseMatUIType[] = [
 ]
 
 function BulkSectionCreateUploadConfirmationTable (props: BulkSectionCreateUploadConfirmationTableProps): JSX.Element {
-  const [tableRows, setTableRows] = useState<Section[]>([])
   const [page, setPage] = useState<number>(0)
 
-  const rowsPerPage = 5
+  const tableRows = props.sectionNames.sort((a, b) => (a.rowNumber < b.rowNumber ? -1 : 1))
 
-  useEffect(() => {
-    setTableRows(props.sectionNames.map(i => {
-      return { rowNumber: i.rowNumber, sectionName: i.sectionName }
-    }).sort((a, b) => (a.rowNumber < b.rowNumber ? -1 : 1))
-    )
-  }, [props.sectionNames])
-
-  return renderTable(tableRows, columns, page, setPage, rowsPerPage)
+  return <ConfirmationTable<Section> {...{ tableRows, columns, page, setPage }} />
 }
 
 export type { BulkSectionCreateUploadConfirmationTableProps, Section }

--- a/ccm_web/client/src/components/ConfirmationTable.tsx
+++ b/ccm_web/client/src/components/ConfirmationTable.tsx
@@ -3,14 +3,29 @@ import React from 'react'
 import StyledTableCell from './StyledTableCell'
 import { TablePaginationActions } from './TablePagination'
 
-interface ConfirmationTableColumn {
-  id: string
+interface ConfirmationEntity {
+  rowNumber: number
+}
+
+interface ConfirmationTableColumn<T> {
+  id: keyof T
   label: string
   minWidth: number
   align?: 'left' | 'right' | undefined
 }
 
-const renderTable = (tableRows: any[], columns: ConfirmationTableColumn[], page: number, setPage: (page: number) => void, rowsPerPage: number): JSX.Element => {
+interface ConfirmationTableProps<T> {
+  tableRows: T[]
+  columns: Array<ConfirmationTableColumn<T>>
+  page: number
+  setPage: (page: number) => void
+}
+
+function ConfirmationTable<T extends ConfirmationEntity> (props: ConfirmationTableProps<T>): JSX.Element {
+  const rowsPerPage = 5
+
+  const { tableRows, columns, page, setPage } = props
+
   const emptyRows = rowsPerPage - Math.min(rowsPerPage, tableRows.length - page * rowsPerPage)
 
   const handleChangePage = (event: unknown, newPage: number): void => {
@@ -24,7 +39,7 @@ const renderTable = (tableRows: any[], columns: ConfirmationTableColumn[], page:
             <TableRow>
               {columns.map((column) => (
                 <StyledTableCell
-                  key={column.id}
+                  key={String(column.id)}
                   align={column.align}
                   style={{ minWidth: column.minWidth }}
                 >
@@ -40,7 +55,7 @@ const renderTable = (tableRows: any[], columns: ConfirmationTableColumn[], page:
                 {columns.map((column) => {
                   const value = row[column.id]
                   return (
-                    <TableCell key={column.id} align={column.align}>
+                    <TableCell key={String(column.id)} align={column.align}>
                       {value}
                     </TableCell>
                   )
@@ -77,4 +92,4 @@ const renderTable = (tableRows: any[], columns: ConfirmationTableColumn[], page:
 }
 
 export type { ConfirmationTableColumn }
-export default renderTable
+export default ConfirmationTable

--- a/ccm_web/client/src/components/GradebookUploadConfirmationTable.tsx
+++ b/ccm_web/client/src/components/GradebookUploadConfirmationTable.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react'
-import renderTable from './ConfirmationTableTableRenderer'
+import React, { useState } from 'react'
+import ConfirmationTable from './ConfirmationTable'
 
 interface StudentGrade {
   rowNumber: number
@@ -25,18 +25,11 @@ const columns: TableHeaderColumnInfoShouldUseMatUIType[] = [
 ]
 
 function GradebookUploadConfirmationTable (props: GradebookUploadConfirmationTableProps): JSX.Element {
-  const [tableRows, setTableRows] = useState<StudentGrade[]>([])
   const [page, setPage] = useState<number>(0)
-  const rowsPerPage = 5
 
-  useEffect(() => {
-    setTableRows(props.grades.map(i => {
-      return { rowNumber: i.rowNumber, uniqname: i.uniqname, grade: i.grade }
-    }).sort((a, b) => (a.rowNumber < b.rowNumber ? -1 : 1))
-    )
-  }, [props.grades])
+  const tableRows = props.grades.sort((a, b) => (a.rowNumber < b.rowNumber ? -1 : 1))
 
-  return renderTable(tableRows, columns, page, setPage, rowsPerPage)
+  return <ConfirmationTable<StudentGrade> {...{ tableRows, columns, page, setPage }} />
 }
 
 export type { GradebookUploadConfirmationTableProps, StudentGrade }


### PR DESCRIPTION
For your consideration, @chrisrrowland. I was going to comment about some of these things, and then I just decided I may as well propose them as changes via a PR. Feel free to reject if you don't like them.

- [x] Make `renderTable` a full-fledged React component, `ConfirmationTable`
- [x] Removed `tableRows` state variables (components will re-render when props containing entities change)
- [x] Use generic to improve typing of parameters for `ConfirmationTable` (`T` can be any entity with a `rowNumber` key, i.e. `StudentGrade` or `Section`).

Note: This has only been minimally tested.